### PR TITLE
Add instance tags

### DIFF
--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -394,23 +394,20 @@ class DiscoAWS(object):
 
         elb = self.update_elb(hostclass, update_autoscaling=False, testing=testing)
 
-        tags = {"hostclass": hostclass,
-                "owner": user_data["owner"],
-                "environment": self.environment_name,
-                "chaos": chaos,
-                "is_testing": "1" if testing else "0"}
-
-        if self.vpc.environment_class:
-            tags['environment_class'] = self.vpc.environment_class
+        tags = {
+            "hostclass": hostclass,
+            "owner": user_data["owner"],
+            "environment": self.environment_name,
+            "environment_class": self.vpc.environment_class,
+            "chaos": chaos,
+            "is_testing": "1" if testing else "0"
+        }
 
         hostclass_option_tags = self.hostclass_option_default(hostclass, "tags")
         if hostclass_option_tags:
-            hostclass_tags = {k.strip(): v.strip() for k, v in
-                              [tag.split(':') for tag in hostclass_option_tags.split(',')]}
-        else:
-            hostclass_tags = {}
-
-        tags.update(hostclass_tags)
+            for tag in hostclass_option_tags.split(','):
+                for key, value in [tag.split(':')]:
+                    tags[key.strip()] = value.strip()
 
         group = self.discogroup.create_or_update_group(
             hostclass=hostclass,

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -49,14 +49,17 @@ class DiscoVPC(object):
     """
     This class contains all our VPC orchestration code
     """
-
+    # Pylint complains this function has too many arguments
+    # pylint: disable=R0913
     def __init__(self, environment_name, environment_type, vpc=None,
                  config_file=None, boto3_ec2=None, defer_creation=False,
-                 aws_config=None, skip_enis_pre_allocate=False, vpc_tags=None):
+                 aws_config=None, skip_enis_pre_allocate=False, vpc_tags=None,
+                 environment_class=None):
         self.config_file = config_file or VPC_CONFIG_FILE
 
         self.environment_name = environment_name
         self.environment_type = environment_type
+        self.environment_class = environment_class
 
         # Lazily initialized
         self._config = None
@@ -207,7 +210,8 @@ class DiscoVPC(object):
             return None
 
         tags = tag2dict(vpcs[0]['Tags'] if 'Tags' in vpcs[0] else None)
-        return cls(tags.get("Name", '-'), tags.get("type", '-'), vpcs[0])
+        return cls(tags.get("Name", '-'), tags.get("type", '-'), vpcs[0],
+                   environment_class=tags.get("environment_class"))
 
     @property
     def disco_vpc_endpoints(self):

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -211,7 +211,7 @@ class DiscoVPC(object):
 
         tags = tag2dict(vpcs[0]['Tags'] if 'Tags' in vpcs[0] else None)
         return cls(tags.get("Name", '-'), tags.get("type", '-'), vpcs[0],
-                   environment_class=tags.get("environment_class"))
+                   environment_class=tags.get("environment_class", 'development'))
 
     @property
     def disco_vpc_endpoints(self):

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.23"
+__version__ = "2.4.24"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_disco_aws.py
+++ b/tests/unit/test_disco_aws.py
@@ -125,6 +125,7 @@ class DiscoAWSTests(TestCase):
         mock_ami = self._get_image_mock(aws)
         aws.update_elb = MagicMock(return_value=None)
         aws.discogroup.elastigroup.spotinst_client = MagicMock()
+        aws.vpc.environment_class = None
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):
@@ -157,6 +158,7 @@ class DiscoAWSTests(TestCase):
         mock_ami = self._get_image_mock(aws)
         aws.update_elb = MagicMock(return_value=None)
         aws.discogroup.elastigroup.spotinst_client = MagicMock()
+        aws.vpc.environment_class = None
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):
@@ -193,6 +195,7 @@ class DiscoAWSTests(TestCase):
         mock_ami = self._get_image_mock(aws)
         aws.update_elb = MagicMock(return_value=None)
         aws.discogroup.elastigroup.spotinst_client = MagicMock()
+        aws.vpc.environment_class = None
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):
@@ -224,6 +227,7 @@ class DiscoAWSTests(TestCase):
         aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, log_metrics=MagicMock())
         aws.update_elb = MagicMock(return_value=None)
         aws.discogroup.elastigroup.spotinst_client = MagicMock()
+        aws.vpc.environment_class = None
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):
@@ -249,6 +253,7 @@ class DiscoAWSTests(TestCase):
         aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, log_metrics=MagicMock())
         aws.update_elb = MagicMock(return_value=None)
         aws.discogroup.elastigroup.spotinst_client = MagicMock()
+        aws.vpc.environment_class = None
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):
@@ -274,6 +279,7 @@ class DiscoAWSTests(TestCase):
         aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, log_metrics=MagicMock())
         aws.update_elb = MagicMock(return_value=None)
         aws.discogroup.elastigroup.spotinst_client = MagicMock()
+        aws.vpc.environment_class = None
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):


### PR DESCRIPTION
Add arbitrary tags to instances from `tags_default` and hostclass `tags` in `disco_aws.ini`.

Read `environment_class` tag from VPC and ad it to instances.