### PR TITLE
Handle SSL Baking

### DIFF
--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -160,7 +160,10 @@ class DiscoELB(object):
             logger.info("Creating target group")
             if port_config:
                 mapping = port_config.port_mappings[0]
-                protocol = mapping.external_protocol
+                if mapping.external_protocol == 'SSL':
+                    protocol = 'TLS'
+                else:
+                    protocol = mapping.external_protocol
                 port = mapping.external_port
                 health_protocol = mapping.internal_protocol
                 health_port = str(mapping.internal_port)


### PR DESCRIPTION
Previous target group implementation did not handle SSL, this now checks if the protocol is SSL and if it is, it creates a target group with a TLS protocol and still uses TCP for the health check protocol which is what boto docs says to use for TLS