### PR TITLE
add application tag to VPCs and nat gateways

### DIFF
--- a/bin/disco_vpc_ui.py
+++ b/bin/disco_vpc_ui.py
@@ -13,7 +13,7 @@ from disco_aws_automation import (
 )
 from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation.disco_logging import configure_logging
-from disco_aws_automation.resource_helper import key_values_to_tags
+from disco_aws_automation.resource_helper import key_values_to_tags, tag2dict
 
 
 def parse_arguments():
@@ -89,7 +89,7 @@ def create_vpc_command(args):
         print("VPC with same name already exists.")
         sys.exit(1)
     else:
-        tags = key_values_to_tags(args.tags) if args.tags else None
+        tags = tag2dict(key_values_to_tags(args.tags)) if args.tags else None
         vpc = DiscoVPC(args.vpc_name, args.vpc_type, skip_enis_pre_allocate=args.skip_enis,
                        vpc_tags=tags)
         print("VPC {0}({1}) has been created".format(args.vpc_name, vpc.get_vpc_id()))

--- a/disco_aws_automation/disco_subnet.py
+++ b/disco_aws_automation/disco_subnet.py
@@ -12,8 +12,8 @@ from .resource_helper import (
     find_or_create,
     create_filters,
     throttled_call,
-    wait_for_state_boto3
-)
+    wait_for_state_boto3,
+    dict_to_boto3_tags)
 
 logger = logging.getLogger(__name__)
 
@@ -390,13 +390,16 @@ class DiscoSubnet(object):
                                        self.name, suffix)
 
     def _apply_subnet_tags(self, resource_id, suffix=None):
+        tags = self.metanetwork.vpc.get_vpc_tags()
+        tags.update({
+            'Name': self._resource_name(suffix),
+            'meta_network': self.metanetwork.name,
+            'subnet': self.name
+        })
+
         tag_params = {
             'Resources': [resource_id],
-            'Tags': [{'Key': 'Name', 'Value': self._resource_name(suffix)},
-                     {'Key': 'meta_network', 'Value': self.metanetwork.name},
-                     {'Key': 'subnet', 'Value': self.name},
-                     {'Key': 'application', 'Value': self.metanetwork.vpc.get_config('application', '')},
-                     {'Key': 'environment', 'Value': self.metanetwork.vpc.environment_name}]
+            'Tags': dict_to_boto3_tags(tags)
         }
 
         keep_trying(300, self.boto3_ec2.create_tags, **tag_params)

--- a/disco_aws_automation/disco_subnet.py
+++ b/disco_aws_automation/disco_subnet.py
@@ -377,6 +377,8 @@ class DiscoSubnet(object):
             throttled_call(self.boto3_ec2.get_waiter('nat_gateway_available').wait,
                            NatGatewayIds=[nat_gateway['NatGatewayId']])
 
+            self._apply_subnet_tags(nat_gateway['NatGatewayId'])
+
             return self._find_nat_gateway()
 
         return None
@@ -392,8 +394,11 @@ class DiscoSubnet(object):
             'Resources': [resource_id],
             'Tags': [{'Key': 'Name', 'Value': self._resource_name(suffix)},
                      {'Key': 'meta_network', 'Value': self.metanetwork.name},
-                     {'Key': 'subnet', 'Value': self.name}]
+                     {'Key': 'subnet', 'Value': self.name},
+                     {'Key': 'application', 'Value': self.metanetwork.vpc.get_config('application', '')},
+                     {'Key': 'environment', 'Value': self.metanetwork.vpc.environment_name}]
         }
+
         keep_trying(300, self.boto3_ec2.create_tags, **tag_params)
 
     def _refresh_route_table(self):

--- a/disco_aws_automation/disco_subnet.py
+++ b/disco_aws_automation/disco_subnet.py
@@ -13,7 +13,8 @@ from .resource_helper import (
     create_filters,
     throttled_call,
     wait_for_state_boto3,
-    dict_to_boto3_tags)
+    dict_to_boto3_tags
+)
 
 logger = logging.getLogger(__name__)
 

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -508,7 +508,8 @@ class DiscoVPC(object):
 
         tag_list = [{'Key': 'Name', 'Value': self.environment_name},
                     {'Key': 'type', 'Value': self.environment_type},
-                    {'Key': 'create_date', 'Value': datetime.utcnow().isoformat()}]
+                    {'Key': 'create_date', 'Value': datetime.utcnow().isoformat()},
+                    {'Key': 'application', 'Value': self.get_config('application', '')}]
 
         if self._vpc_tags:
             # Add the extra tags to the list of default tags

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -37,7 +37,7 @@ from .disco_vpc_endpoints import DiscoVPCEndpoints
 from .disco_vpc_gateways import DiscoVPCGateways
 from .disco_vpc_peerings import DiscoVPCPeerings
 from .disco_vpc_sg_rules import DiscoVPCSecurityGroupRules
-from .resource_helper import (tag2dict, create_filters, keep_trying, throttled_call)
+from .resource_helper import (tag2dict, create_filters, keep_trying, throttled_call, dict_to_boto3_tags)
 from .exceptions import (IPRangeError, VPCConfigError, VPCEnvironmentError)
 
 logger = logging.getLogger(__name__)
@@ -497,6 +497,21 @@ class DiscoVPC(object):
 
         logger.debug("vpc: %s", self.vpc)
 
+    def get_vpc_tags(self):
+        """Get tags for this VPC"""
+        tags = {
+            'Name': self.environment_name,
+            'type': self.environment_type,
+            'create_date': datetime.utcnow().isoformat(),
+            'application': self.get_config('application', '')
+        }
+
+        if self._vpc_tags:
+            # Add the extra tags to the list of default tags
+            tags.update(self._vpc_tags)
+
+        return tags
+
     def _add_vpc_tags(self):
         """
         Add tags to VPC. This function will add the default tags and the tags specified on the create
@@ -506,16 +521,9 @@ class DiscoVPC(object):
         ec2 = boto3.resource('ec2')
         vpc = ec2.Vpc(self.vpc['VpcId'])
 
-        tag_list = [{'Key': 'Name', 'Value': self.environment_name},
-                    {'Key': 'type', 'Value': self.environment_type},
-                    {'Key': 'create_date', 'Value': datetime.utcnow().isoformat()},
-                    {'Key': 'application', 'Value': self.get_config('application', '')}]
+        tags = self.get_vpc_tags()
 
-        if self._vpc_tags:
-            # Add the extra tags to the list of default tags
-            tag_list.extend(self._vpc_tags)
-
-        tags = throttled_call(vpc.create_tags, Tags=tag_list)
+        tags = throttled_call(vpc.create_tags, Tags=dict_to_boto3_tags(tags))
         logger.debug("vpc tags: %s", tags)
 
     def configure_notifications(self, dry_run=False):

--- a/disco_aws_automation/resource_helper.py
+++ b/disco_aws_automation/resource_helper.py
@@ -47,6 +47,18 @@ def key_values_to_tags(dicts):
             for tag_key_value in [key_value_option.split(":", 1) for key_value_option in dicts]]
 
 
+def dict_to_boto3_tags(tag_dict):
+    """
+    Convenience function for converting a dictionary to boto3 tags
+    :param tag_dict: A dictionary of str to str.
+    :return: A list of boto3 tags.
+    """
+    return [
+        {"Key": key, "Value": value}
+        for key, value in tag_dict.items()
+    ]
+
+
 def find_or_create(find, create):
     """Given a find and a create function, create a resource if it doesn't exist"""
     result = find()

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.30"
+__version__ = "2.4.31"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/sample_configuration/disco_vpc.ini
+++ b/sample_configuration/disco_vpc.ini
@@ -21,6 +21,8 @@ tunnel_cidr=10.101.16.0/20
 dmz_cidr=10.101.32.0/20
 maintenance_cidr=10.101.48.0/20
 
+application=test
+
 tunnel_sg_rules=tcp all 80 443, tcp maintenance 22, udp all 123
 tunnel_igw_routes=0.0.0.0/0
 intranet_sg_rules=tcp all 0:65535, udp intranet 0:65535, tcp dmz 2181

--- a/tests/unit/test_disco_subnet.py
+++ b/tests/unit/test_disco_subnet.py
@@ -1,7 +1,6 @@
 """Tests of disco_subnet"""
-from unittest import TestCase
 import copy
-
+from unittest import TestCase
 from mock import MagicMock, call
 
 from disco_aws_automation.disco_subnet import (
@@ -9,7 +8,6 @@ from disco_aws_automation.disco_subnet import (
     DYNO_NAT_TAG_KEY
 )
 from tests.helpers.patch_disco_aws import TEST_ENV_NAME
-
 
 MOCK_SUBNET_NAME = 'availability_zone_1'
 MOCK_CIDR = '10.101.0.0/16'
@@ -43,12 +41,16 @@ MOCK_NAT_GATEWAY = {'VpcId': MOCK_VPC_ID,
                     'NatGatewayAddresses': [{'AllocationId': MOCK_ALLOCATION_ID,
                                              'PublicIp': MOCK_PUBLIC_IP}]}
 MOCK_ROUTE = {'RouteId': 'route_id'}
-MOCK_TAG = [{'Value': "{0}_{1}_{2}".format(TEST_ENV_NAME,
-                                           MOCK_VPC_NAME,
-                                           MOCK_SUBNET_NAME),
-             'Key': 'Name'},
-            {'Value': 'mock_vpc_name', 'Key': 'meta_network'},
-            {'Value': 'availability_zone_1', 'Key': 'subnet'}]
+MOCK_TAG = [
+    {
+        'Key': 'Name',
+        'Value': "{0}_{1}_{2}".format(TEST_ENV_NAME, MOCK_VPC_NAME, MOCK_SUBNET_NAME),
+    },
+    {'Key': 'meta_network', 'Value': 'mock_vpc_name', },
+    {'Key': 'subnet', 'Value': 'availability_zone_1'},
+    {'Key': 'application', 'Value': 'test'},
+    {'Key': 'environment', 'Value': 'unittestenv'}
+]
 
 
 def _get_metanetwork_mock():
@@ -57,6 +59,15 @@ def _get_metanetwork_mock():
     ret.vpc = MagicMock()
     ret.vpc.environment_name = TEST_ENV_NAME
     ret.vpc.vpc = {'VpcId': MOCK_VPC_ID}
+
+    # pylint: disable=unused-argument
+    def _mock_get_config(option, default=None):
+        if option == 'application':
+            return 'test'
+
+        return None
+
+    ret.vpc.get_config.side_effect = _mock_get_config
     return ret
 
 

--- a/tests/unit/test_disco_subnet.py
+++ b/tests/unit/test_disco_subnet.py
@@ -42,14 +42,14 @@ MOCK_NAT_GATEWAY = {'VpcId': MOCK_VPC_ID,
                                              'PublicIp': MOCK_PUBLIC_IP}]}
 MOCK_ROUTE = {'RouteId': 'route_id'}
 MOCK_TAG = [
+    {'Key': 'environment', 'Value': 'unittestenv'},
+    {'Key': 'application', 'Value': 'test'},
+    {'Key': 'meta_network', 'Value': 'mock_vpc_name', },
     {
         'Key': 'Name',
         'Value': "{0}_{1}_{2}".format(TEST_ENV_NAME, MOCK_VPC_NAME, MOCK_SUBNET_NAME),
     },
-    {'Key': 'meta_network', 'Value': 'mock_vpc_name', },
-    {'Key': 'subnet', 'Value': 'availability_zone_1'},
-    {'Key': 'application', 'Value': 'test'},
-    {'Key': 'environment', 'Value': 'unittestenv'}
+    {'Key': 'subnet', 'Value': 'availability_zone_1'}
 ]
 
 
@@ -60,14 +60,13 @@ def _get_metanetwork_mock():
     ret.vpc.environment_name = TEST_ENV_NAME
     ret.vpc.vpc = {'VpcId': MOCK_VPC_ID}
 
-    # pylint: disable=unused-argument
-    def _mock_get_config(option, default=None):
-        if option == 'application':
-            return 'test'
+    def _get_vpc_tags_mock():
+        return {
+            'application': 'test',
+            'environment': 'unittestenv'
+        }
 
-        return None
-
-    ret.vpc.get_config.side_effect = _mock_get_config
+    ret.vpc.get_vpc_tags.side_effect = _get_vpc_tags_mock
     return ret
 
 
@@ -183,8 +182,10 @@ class DiscoSubnetTests(TestCase):
                      {'Values': [MOCK_VPC_ID], 'Name': 'vpc-id'},
                      {'Values': [MOCK_SUBNET_NAME], 'Name': 'availabilityZone'}])
 
-        self.mock_ec2_conn.create_tags.assert_called_once_with(Resources=[MOCK_SUBNET_ID],
-                                                               Tags=MOCK_TAG)
+        self.mock_ec2_conn.create_tags.assert_called_once_with(
+            Resources=[MOCK_SUBNET_ID],
+            Tags=MOCK_TAG
+        )
 
     def test_create_brand_new_subnet(self):
         """ Verify that a brand new subnet is properly created """

--- a/tests/unit/test_disco_vpc.py
+++ b/tests/unit/test_disco_vpc.py
@@ -153,7 +153,8 @@ class DiscoVPCTests(unittest.TestCase):
                 'tunnel_cidr': 'auto',
                 'dmz_cidr': 'auto',
                 'maintenance_cidr': 'auto',
-                'ntp_server': '10.0.0.5'
+                'ntp_server': '10.0.0.5',
+                'application': 'test'
             }
         })
 
@@ -185,7 +186,8 @@ class DiscoVPCTests(unittest.TestCase):
                                      {'Value': 'auto-vpc-type', 'Key': 'type'},
                                      {'Value': 'ANY', 'Key': 'create_date'},
                                      {'Value': 'astronauts', 'Key': 'productline'},
-                                     {'Value': 'tag_value', 'Key': 'mytag'}]
+                                     {'Value': 'tag_value', 'Key': 'mytag'},
+                                     {'Value': 'test', 'Key': 'application'}]
 
                 DiscoVPC('auto-vpc', 'auto-vpc-type', vpc_tags=my_tags_options)
                 # Get the create_tags argument
@@ -194,7 +196,7 @@ class DiscoVPCTests(unittest.TestCase):
                 self.assertEqual(['Tags'], call_args_tags.keys())
                 call_tags_dict = call_args_tags['Tags']
                 # Verify the number of tag Dictionaries in the list
-                self.assertEqual(5, len(call_tags_dict))
+                self.assertEqual(6, len(call_tags_dict))
                 # Verify each tag options
                 for tag_option in call_tags_dict:
                     if tag_option['Key'] == 'create_date':

--- a/tests/unit/test_disco_vpc.py
+++ b/tests/unit/test_disco_vpc.py
@@ -174,8 +174,10 @@ class DiscoVPCTests(unittest.TestCase):
 
         client_mock.describe_vpn_gateways.return_value = {'VpnGateways': []}
 
-        my_tags_options = [{'Value': 'astronauts', 'Key': 'productline'},
-                           {'Value': 'tag_value', 'Key': 'mytag'}]
+        my_tags_options = {
+            'productline': 'astronauts',
+            'mytag': 'tag_value'
+        }
         DiscoVPC._get_vpc_cidr = MagicMock()
         DiscoVPC._get_vpc_cidr.return_value = '10.0.0.0/26'
         with patch("disco_aws_automation.DiscoVPC._create_new_meta_networks",
@@ -196,7 +198,7 @@ class DiscoVPCTests(unittest.TestCase):
                 self.assertEqual(['Tags'], call_args_tags.keys())
                 call_tags_dict = call_args_tags['Tags']
                 # Verify the number of tag Dictionaries in the list
-                self.assertEqual(6, len(call_tags_dict))
+                # self.assertEqual(6, len(call_tags_dict))
                 # Verify each tag options
                 for tag_option in call_tags_dict:
                     if tag_option['Key'] == 'create_date':

--- a/tests/unit/test_disco_vpc.py
+++ b/tests/unit/test_disco_vpc.py
@@ -198,7 +198,7 @@ class DiscoVPCTests(unittest.TestCase):
                 self.assertEqual(['Tags'], call_args_tags.keys())
                 call_tags_dict = call_args_tags['Tags']
                 # Verify the number of tag Dictionaries in the list
-                # self.assertEqual(6, len(call_tags_dict))
+                self.assertEqual(6, len(call_tags_dict))
                 # Verify each tag options
                 for tag_option in call_tags_dict:
                     if tag_option['Key'] == 'create_date':


### PR DESCRIPTION
See https://github.com/amplify-education/asiaq/compare/add_application_tag_vpcs?expand=1#diff-a60e6464abce4b70d5207f2f68e35ea8R24

Add a `application` config option to `disco_vpc.ini` and use it to tag VPCs, subnets and other resources