### PR TITLE
Configure spotinst to revert on ondemand instances to spot instance at midnight each day

### DIFF
--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -202,7 +202,20 @@ class DiscoElastigroup(BaseGroup):
         strategy = {
             'availabilityVsCost': "availabilityOriented",
             'utilizeReservedInstances': True,
-            'fallbackToOd': True
+            'fallbackToOd': True,
+            "revertToSpot": {
+                "performAt": "timeWindow",
+                # time is in UTC. This is midnight EST
+                "timeWindows": [
+                    "Sun:04:00-Sun:05:00",
+                    "Mon:04:00-Mon:05:00",
+                    "Tue:04:00-Tue:05:00",
+                    "Wed:04:00-Wed:05:00",
+                    "Thu:04:00-Thu:05:00",
+                    "Fri:04:00-Fri:05:00",
+                    "Sat:04:00-Sat:05:00"
+                ]
+            }
         }
 
         strategy.update(self._get_risk_config(spotinst_reserve))

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.32"
+__version__ = "2.4.33"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_disco_elastigroup.py
+++ b/tests/unit/test_disco_elastigroup.py
@@ -211,7 +211,19 @@ class DiscoElastigroupTests(TestCase):
                     'availabilityVsCost': 'availabilityOriented',
                     'fallbackToOd': True,
                     'risk': 100,
-                    'utilizeReservedInstances': True
+                    'utilizeReservedInstances': True,
+                    "revertToSpot": {
+                        "performAt": "timeWindow",
+                        "timeWindows": [
+                            "Sun:04:00-Sun:05:00",
+                            "Mon:04:00-Mon:05:00",
+                            "Tue:04:00-Tue:05:00",
+                            "Wed:04:00-Wed:05:00",
+                            "Thu:04:00-Thu:05:00",
+                            "Fri:04:00-Fri:05:00",
+                            "Sat:04:00-Sat:05:00"
+                        ]
+                    }
                 },
                 'capacity': {
                     'minimum': 1,
@@ -524,7 +536,8 @@ class DiscoElastigroupTests(TestCase):
                     "availabilityVsCost": ANY,
                     "risk": risk,
                     "onDemandCount": on_demand_count,
-                    "fallbackToOd": ANY
+                    "fallbackToOd": ANY,
+                    "revertToSpot": ANY
                 }
             }
         }


### PR DESCRIPTION
We need this option in order for spotinst to revert any extra on demand instances we have back to spot instances.

This could happen if spotinst was unable to find a spot instance at some point and used ondemand for a hostclass. It would then never switch back to spot instances even when they bacame available because we were missing this option