### PR TITLE
p2.7-compatible netaddr

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -6,7 +6,7 @@ docopt>=0.6.1,<1
 passlib>=1.6.1,<2
 pytz>=2014.7
 iso8601>=0.1.10,<1
-netaddr>=0.7.12,<1
+netaddr>=0.7.12,<0.7.19
 python-dateutil>=2.4.0,<2.7.0
 semantic_version>=2.4.2
 requests_aws4auth<2


### PR DESCRIPTION
netaddr 0.8.0 pulls p2.7-incompatible lib (zipp)
```
- netaddr [required: >=0.7.12,<1, installed: 0.8.0]
    - importlib-resources [required: Any, installed: 3.0.0]
      - contextlib2 [required: Any, installed: 0.6.0.post1]
      - pathlib2 [required: Any, installed: 2.3.5]
        - scandir [required: Any, installed: 1.10.0]
        - six [required: Any, installed: 1.15.0]
      - singledispatch [required: Any, installed: 3.4.0.3]
        - six [required: Any, installed: 1.15.0]
      - typing [required: Any, installed: 3.7.4.1]
      - zipp [required: >=0.4, installed: 3.1.0]
```