### PR TITLE
Update python packages

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -17,3 +17,5 @@ elasticsearch>=1.0.0,<2.0.0
 # so let's pin it back until that issue is resolved properly:
 # https://github.com/jaraco/zipp/issues/50
 zipp>=1.2.0,<2
+# highest versions throw an error as has dropping python 2.7 support
+importlib-resources<=3.3.1


### PR DESCRIPTION
Set a fixed version of `importlib-resources` as newest versions throwing errors

![Screen Shot 2020-12-30 at 3 33 12 PM](https://user-images.githubusercontent.com/4427554/103354617-afdd0b80-4ab4-11eb-92e6-1f8c5e118b44.png)
