### PR TITLE
lock contextlib2

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.44"
+__version__ = "2.4.45"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/requirements.pip
+++ b/requirements.pip
@@ -19,3 +19,4 @@ elasticsearch>=1.0.0,<2.0.0
 zipp>=1.2.0,<2
 # highest versions throw an error as has dropping python 2.7 support
 importlib-resources<=3.3.1
+contextlib2<0.7


### PR DESCRIPTION
From the cron email, we can see an error related with `contextlib2`
And recently they released a [new ](https://pypi.org/project/contextlib2/21.6.0/)version of that library 
In which drop python 2 support, so locking version based on release [history](https://pypi.org/project/contextlib2/21.6.0/#history)
```
Cronic detected failure or error output for the command:
/opt/wgen/bin/take_snapshot.sh

RESULT CODE: 3

ERROR OUTPUT:
Traceback (most recent call last):
  File "/bin/disco_snapshot.py", line 8, in <module>
    from disco_aws_automation import DiscoAWS
  File "/usr/lib/python2.7/site-packages/disco_aws_automation/__init__.py", line 7, in <module>
    from .disco_aws import DiscoAWS
  File "/usr/lib/python2.7/site-packages/disco_aws_automation/disco_aws.py", line 28, in <module>
    from .disco_bake import DiscoBake
  File "/usr/lib/python2.7/site-packages/disco_aws_automation/disco_bake.py", line 25, in <module>
    from .disco_vpc import DiscoVPC
  File "/usr/lib/python2.7/site-packages/disco_aws_automation/disco_vpc.py", line 18, in <module>
    from netaddr import IPNetwork, IPAddress
  File "/usr/lib/python2.7/site-packages/netaddr/__init__.py", line 18, in <module>
    from netaddr.core import (AddrConversionError, AddrFormatError,
  File "/usr/lib/python2.7/site-packages/netaddr/core.py", line 11, in <module>
    from netaddr.compat import _callable, _iter_dict_keys
  File "/usr/lib/python2.7/site-packages/netaddr/compat.py", line 93, in <module>
    import importlib_resources as _importlib_resources
  File "/usr/lib/python2.7/site-packages/importlib_resources/__init__.py", line 5, in <module>
    from ._common import (
  File "/usr/lib/python2.7/site-packages/importlib_resources/_common.py", line 9, in <module>
    from ._compat import (
  File "/usr/lib/python2.7/site-packages/importlib_resources/_compat.py", line 15, in <module>
    from contextlib2 import suppress                         # type: ignore
  File "/usr/lib/python2.7/site-packages/contextlib2/__init__.py", line 56
    async def __aenter__(self):
            ^
SyntaxError: invalid syntax
Failed to take snapshot of volume vol-07bfa228c802de4d5

STANDARD OUTPUT:
Attempting snapshot of EBS volume on dbmghi-i-0cbdce400e8b085d1 in staging
```