### PR TITLE
Feat: AT-5181 switch spotinst to use equalAzDistribution

### DIFF
--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -200,7 +200,7 @@ class DiscoElastigroup(BaseGroup):
         # pylint: disable=too-many-arguments, too-many-locals
         """Create new elastigroup configuration"""
         strategy = {
-            'availabilityVsCost': "availabilityOriented",
+            'availabilityVsCost': "equalAzDistribution",
             'utilizeReservedInstances': True,
             'fallbackToOd': True,
             "revertToSpot": {

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.48"
+__version__ = "2.4.49"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_disco_elastigroup.py
+++ b/tests/unit/test_disco_elastigroup.py
@@ -208,7 +208,7 @@ class DiscoElastigroupTests(TestCase):
                 },
                 'strategy': {
                     'onDemandCount': None,
-                    'availabilityVsCost': 'availabilityOriented',
+                    'availabilityVsCost': 'equalAzDistribution',
                     'fallbackToOd': True,
                     'risk': 100,
                     'utilizeReservedInstances': True,


### PR DESCRIPTION
From the Generous Bear incident, we notice new instances were favoring a specific AZ instead of it being equally distributed across all AZ's. This impacts reliability in a way if an AZ is having issues and instances were being deployed to that AZ. So we are switching Spotinst to equally distribute instances across the AZ's.