### PR TITLE
lock boto3

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.49"
+__version__ = "2.4.50"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/jenkins/boto_init.sh
+++ b/jenkins/boto_init.sh
@@ -59,7 +59,7 @@ function boto_init_activate {
     export PATH=/opt/wgen-3p/python27/bin:$PATH
     virtualenv $boto_tmp_dir > /dev/null
     source $boto_tmp_dir/bin/activate > /dev/null
-    pip install pip==20.3 > /dev/null # limit upgrade to version that supports python 2.7
+    pip install pip<"21" > /dev/null # limit upgrade to version that supports python 2.7
     pip install --upgrade wheel > /dev/null # upgrades wheel so the install succeeds
     pip install ${SELF_DIR}/.. > /dev/null  # installs asiaq
 }

--- a/jenkins/boto_init.sh
+++ b/jenkins/boto_init.sh
@@ -59,8 +59,8 @@ function boto_init_activate {
     export PATH=/opt/wgen-3p/python27/bin:$PATH
     virtualenv $boto_tmp_dir > /dev/null
     source $boto_tmp_dir/bin/activate > /dev/null
-    pip install pip<"21" > /dev/null # limit upgrade to version that supports python 2.7
-    pip install --upgrade wheel > /dev/null # upgrades wheel so the install succeeds
+    pip install -U "pip<21" > /dev/null # limit upgrade to version that supports python 2.7
+    pip install -U wheel > /dev/null # upgrades wheel so the install succeeds
     pip install ${SELF_DIR}/.. > /dev/null  # installs asiaq
 }
 

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,7 +1,7 @@
 # Place dependencies in this file, following the distutils format:
 # http://docs.python.org/2/distutils/setupscript.html#relationships-between-distributions-and-packages
 boto>=2.38.0,<3
-boto3>=1.4.0,<1.18
+boto3>=1.7.0,<1.18
 docopt>=0.6.1,<1
 passlib>=1.6.1,<2
 pytz>=2014.7

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,7 +1,7 @@
 # Place dependencies in this file, following the distutils format:
 # http://docs.python.org/2/distutils/setupscript.html#relationships-between-distributions-and-packages
 boto>=2.38.0,<3
-boto3>=1.4.0,<2
+boto3>=1.4.0,<1.18
 docopt>=0.6.1,<1
 passlib>=1.6.1,<2
 pytz>=2014.7


### PR DESCRIPTION
Version 1.18.0 requires: Python >= 3.6 so locking a package to reduce risk of failure
https://pypi.org/project/boto3/1.18.0/

Also, it is like we are having issues in the Jenkins [job](https://astrojenkins-build.aws.wgen.net/view/bake-test-promote/job/bake-hostclass/42557/console) related to it